### PR TITLE
Fix example YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Then install the gem with Bundler
 Then add the gem to your Jekyll configuration.
 
     gems:
-      -octopress-linkblog
+      - octopress-linkblog
 
 ## Usage
 


### PR DESCRIPTION
Fixed gem inclusion in example config YAML so it is read as an array element and not a `-`-prefixed string.